### PR TITLE
Forward modified ResponseWriters

### DIFF
--- a/adapter_test.go
+++ b/adapter_test.go
@@ -100,7 +100,7 @@ func TestWrap(t *testing.T) {
 	engine.GET("/", func(c *gin.Context) {
 		assert.Equal("value", c.Request.Context().Value("test"), "context should be passsed through from middleware")
 
-		// This Write validates that the writed, modified by the wrapped middleware, is propagated.
+		// This Write validates that the writer, modified by the wrapped middleware, is propagated.
 		c.Writer.Write([]byte("test"))
 	})
 


### PR DESCRIPTION
Previously, when a response write would be modified, it was ignored.

This PR adds functionality for capturing modified ReponseWriters and using them.